### PR TITLE
Fix a couple of issue during my initial setup

### DIFF
--- a/acjapp/pairwise/utils.py
+++ b/acjapp/pairwise/utils.py
@@ -218,7 +218,7 @@ def make_groups(setid, judgelist):
         bestgroup = []
         bestagreement = 0
         corrstats_df = None
-        return bestgroup, bestagreement, corrstats_df
+        return bestgroup, bestagreement, corrstats_df, []
     set_judge_script_rank = {}
     for judge in judgelist:
         computed_scripts = get_computed_scripts(setobject, [judge])
@@ -231,7 +231,7 @@ def make_groups(setid, judgelist):
         bestgroup = judgelist
         bestagreement = coef
         corrstats_df = pandas.DataFrame(set_judge_script_rank)
-        return bestgroup, bestagreement, corrstats_df
+        return bestgroup, bestagreement, corrstats_df, []
     else:
         judgepairs = itertools.combinations(judgelist, 2)
         judgepaircorr = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asgiref==3.4.1
-backports.zoneinfo==0.2.1
+backports.zoneinfo==0.2.1;python_version<"3.9"
 DateTime==4.3
 defusedxml==0.7.1
 diff-match-patch==20200713


### PR DESCRIPTION
 thanks for the good work! This PR is to fix the following issue:

1. backports are included in the later version of python so this is to make it optional for > 3.9
2. `migrations/__init__.py` was missing in pairwise
3. the return values were inconsistent in the early exits